### PR TITLE
Add FunctionalTestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "php": "^7.2"
     },
     "conflict": {
-        "phpunit/phpunit": "<8.0",
-        "contao/core-bundle": "<4.9"
+        "contao/core-bundle": "<4.9",
+        "phpunit/phpunit": "<8.0"
     },
     "require-dev": {
         "ext-pdo": "*",

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,14 @@
         "php": "^7.2"
     },
     "conflict": {
-        "phpunit/phpunit": "<8.0"
+        "phpunit/phpunit": "<8.0",
+        "contao/core-bundle": "<4.9"
     },
     "require-dev": {
         "ext-pdo": "*",
-        "contao/core-bundle": "^4.5",
+        "contao/core-bundle": "^4.9",
+        "doctrine/dbal": "^2.10",
+        "doctrine/orm": "^2.6.3",
         "friendsofphp/php-cs-fixer": "^2.12",
         "php-http/guzzle6-adapter": "^1.1"
     },

--- a/src/ContaoDatabaseTrait.php
+++ b/src/ContaoDatabaseTrait.php
@@ -17,6 +17,9 @@ use Doctrine\DBAL\DriverManager;
 
 trait ContaoDatabaseTrait
 {
+    /**
+     * @var Connection
+     */
     private static $connection;
 
     protected static function loadFileIntoDatabase(string $sqlFile): void

--- a/src/FunctionalTestCase.php
+++ b/src/FunctionalTestCase.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Contao\TestCase;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+abstract class FunctionalTestCase extends WebTestCase
+{
+    protected function loadFixture(string $yamlFile, bool $resetDatabase = true)
+    {
+        self::bootKernel();
+
+        $doctrine = self::$container->get('doctrine');
+
+        /** @var Connection $connection */
+        $connection = $doctrine->getConnection();
+
+        if ($resetDatabase) {
+            $this->resetDatabase();
+        }
+
+        $data = Yaml::parseFile($yamlFile);
+
+        foreach ($data as $table => $rows) {
+            foreach ($rows as $row) {
+                if ('sql' === $table) {
+                    $connection->exec($row);
+                    continue;
+                }
+
+                $connection->insert($table, $row);
+            }
+        }
+    }
+
+    private function resetDatabase()
+    {
+        $doctrine = self::$container->get('doctrine');
+
+        /** @var Connection $connection */
+        $connection = $doctrine->getConnection();
+        $schemaManager = $connection->getSchemaManager();
+
+        /** @var Table $table */
+        foreach ($schemaManager->listTables() as $table) {
+            $connection->exec('DROP TABLE '.$table->getName());
+        }
+
+        /** @var EntityManagerInterface $manager */
+        $manager = $doctrine->getManager();
+
+        $metadata = $manager->getMetadataFactory()->getAllMetadata();
+
+        $tool = new SchemaTool($manager);
+
+        $tool->createSchema($metadata);
+    }
+}

--- a/src/FunctionalTestCase.php
+++ b/src/FunctionalTestCase.php
@@ -11,7 +11,7 @@ use Symfony\Component\Yaml\Yaml;
 
 abstract class FunctionalTestCase extends WebTestCase
 {
-    protected function loadFixture(string $yamlFile, bool $resetDatabase = true)
+    protected function loadFixture(string $yamlFile, bool $resetDatabase = true): void
     {
         self::bootKernel();
 
@@ -38,7 +38,7 @@ abstract class FunctionalTestCase extends WebTestCase
         }
     }
 
-    private function resetDatabase()
+    private function resetDatabase(): void
     {
         $doctrine = self::$container->get('doctrine');
 
@@ -53,11 +53,9 @@ abstract class FunctionalTestCase extends WebTestCase
 
         /** @var EntityManagerInterface $manager */
         $manager = $doctrine->getManager();
-
         $metadata = $manager->getMetadataFactory()->getAllMetadata();
 
         $tool = new SchemaTool($manager);
-
         $tool->createSchema($metadata);
     }
 }


### PR DESCRIPTION
This adds a helper class to ease functional test fixtures.

**Example Test:***
```php
use Contao\TestCase\FunctionalTestCase;

class DatabaseTest extends FunctionalTestCase
{
    protected function setUp(): void
    {
        parent::setUp();

        $this->loadFixture(__DIR__.'/../Fixtures/Functional/test.yml');
    }

    public function testNothing()
    {
        // nothing
    }
}
```

**Example YAML:**
```yaml
tl_user:
    - name: Foo
      email: foo@bar.com

sql:
    - "UPDATE tl_user SET admin='1'"
```