### PR TITLE
Add 'request_stack' service to default Contao container

### DIFF
--- a/src/ContaoTestCase.php
+++ b/src/ContaoTestCase.php
@@ -76,12 +76,15 @@ abstract class ContaoTestCase extends TestCase
     protected function getContainerWithContaoConfiguration(string $projectDir = ''): ContainerBuilder
     {
         $container = new ContainerBuilder();
+        
         $container->setParameter('kernel.debug', false);
         $container->setParameter('kernel.charset', 'UTF-8');
         $container->setParameter('kernel.default_locale', 'en');
         $container->setParameter('kernel.cache_dir', $projectDir.'/var/cache');
         $container->setParameter('kernel.project_dir', $projectDir);
         $container->setParameter('kernel.root_dir', $projectDir.'/app');
+
+        $container->setDefinition('request_stack', new Definition(RequestStack::class));
 
         // Load the default configuration
         $extension = new ContaoCoreExtension();

--- a/src/ContaoTestCase.php
+++ b/src/ContaoTestCase.php
@@ -76,7 +76,6 @@ abstract class ContaoTestCase extends TestCase
     protected function getContainerWithContaoConfiguration(string $projectDir = ''): ContainerBuilder
     {
         $container = new ContainerBuilder();
-        
         $container->setParameter('kernel.debug', false);
         $container->setParameter('kernel.charset', 'UTF-8');
         $container->setParameter('kernel.default_locale', 'en');


### PR DESCRIPTION
This thing is missing in many tests. :upside_down_face: 