### PR TITLE
Allow Doctrine 3 and fix missing container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "ext-pdo": "*",
         "contao/core-bundle": "^4.9",
-        "doctrine/dbal": "^2.11 || 3.0",
+        "doctrine/dbal": "^2.11 || ^3.0",
         "doctrine/orm": "^2.6.3",
         "friendsofphp/php-cs-fixer": "^2.12",
         "php-http/guzzle6-adapter": "^1.1"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "ext-pdo": "*",
         "contao/core-bundle": "^4.9",
-        "doctrine/dbal": "^2.10",
+        "doctrine/dbal": "^2.11 || 3.0",
         "doctrine/orm": "^2.6.3",
         "friendsofphp/php-cs-fixer": "^2.12",
         "php-http/guzzle6-adapter": "^1.1"

--- a/src/ContaoDatabaseTrait.php
+++ b/src/ContaoDatabaseTrait.php
@@ -28,7 +28,7 @@ trait ContaoDatabaseTrait
             throw new \InvalidArgumentException(sprintf('File "%s" does not exist', $sqlFile));
         }
 
-        static::getConnection()->exec(file_get_contents($sqlFile));
+        static::getConnection()->executeStatement(file_get_contents($sqlFile));
     }
 
     protected static function getConnection(): Connection

--- a/src/FunctionalTestCase.php
+++ b/src/FunctionalTestCase.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\TestCase;
 
+use Contao\System;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;
@@ -27,6 +28,7 @@ abstract class FunctionalTestCase extends WebTestCase
             throw new \RuntimeException('Please boot the kernel before calling '.__METHOD__);
         }
 
+        System::setContainer(self::$container);
         $doctrine = self::$container->get('doctrine');
 
         /** @var Connection $connection */
@@ -37,7 +39,7 @@ abstract class FunctionalTestCase extends WebTestCase
 
             /** @var Table $table */
             foreach ($connection->getSchemaManager()->listTables() as $table) {
-                $connection->exec($platform->getTruncateTableSQL($table->getName()));
+                $connection->executeStatement($platform->getTruncateTableSQL($table->getName()));
             }
         }
 
@@ -66,7 +68,7 @@ abstract class FunctionalTestCase extends WebTestCase
 
         /** @var Table $table */
         foreach ($schemaManager->listTables() as $table) {
-            $connection->exec($platform->getDropTableSQL($table));
+            $connection->executeStatement($platform->getDropTableSQL($table));
         }
 
         /** @var EntityManagerInterface $manager */
@@ -84,7 +86,7 @@ abstract class FunctionalTestCase extends WebTestCase
         foreach ($data as $table => $rows) {
             foreach ($rows as $row) {
                 if ('sql' === $table) {
-                    $connection->exec($row);
+                    $connection->executeStatement($row);
                     continue;
                 }
 

--- a/src/FunctionalTestCase.php
+++ b/src/FunctionalTestCase.php
@@ -28,7 +28,6 @@ abstract class FunctionalTestCase extends WebTestCase
             throw new \RuntimeException('Please boot the kernel before calling '.__METHOD__);
         }
 
-        System::setContainer(self::$container);
         $doctrine = self::$container->get('doctrine');
 
         /** @var Connection $connection */

--- a/src/FunctionalTestCase.php
+++ b/src/FunctionalTestCase.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Contao\TestCase;
 
-use Contao\System;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;


### PR DESCRIPTION
This fixes the failing tests in https://github.com/contao/contao/pull/4026 because creating the DB schema might call our `DcaSchemaProvider` which requires a container to work.

While adding the lines I noticed we don't allow Doctrine 3 but I'm pretty sure we should for Contao 4.13 😅 